### PR TITLE
Make sure to mark newly loaded files as "non-mocks"

### DIFF
--- a/src/services/oni-save/reducer/receive-onisave.ts
+++ b/src/services/oni-save/reducer/receive-onisave.ts
@@ -24,7 +24,8 @@ export default function receiveOniSaveReducer(
         loadError: null,
         loadingStatus: action.meta.operation,
         loadingProgressMessage: null,
-        saveGame: action.payload.clearExisting ? null : state.saveGame
+        saveGame: action.payload.clearExisting ? null : state.saveGame,
+        isMock: false
       };
     case ACTION_RECEIVE_ONISAVE_ERROR:
       state = {


### PR DESCRIPTION
**Bug:**

Example status keeps after having the example loaded once, followed by loading an actual file

**Reproduction:**

1. Open the app
2. Load the example json
3. Press the load icon on the toolbar to load your own save game

**Expectation:**

The "example" indicator is removed, and I can "export" my save after I make modifications

**Reality:**

The example indicator stays, and the save icon keeps locked, even after loading an non example save game

**Fix:**

During the loading of a save-game, the mock status will be reset